### PR TITLE
Fix wheel_separation value

### DIFF
--- a/sam_bot_description/src/description/sam_bot_description.urdf
+++ b/sam_bot_description/src/description/sam_bot_description.urdf
@@ -231,7 +231,7 @@
       <right_joint>drivewhl_r_joint</right_joint>
 
       <!-- kinematics -->
-      <wheel_separation>0.025</wheel_separation>
+      <wheel_separation>0.4</wheel_separation>
       <wheel_diameter>0.2</wheel_diameter>
 
       <!-- limits -->	


### PR DESCRIPTION
The parameter `wheel_separation` of `diff_drive` is set to an incorrect value, causing rotation rate to be slower than the desired value.

The correct value is: `base_width + wheel_width + 2 * wheel_ygap` which equals to 0.4 m.

Visualized:
![image](https://user-images.githubusercontent.com/26688819/143512145-0095e6af-7682-42f7-897b-388143e58584.png)

Note: navigation.ros.org is affected too ([this file](https://raw.githubusercontent.com/ros-planning/navigation.ros.org/master/setup_guides/odom/setup_odom.rst)). I'll make a PR there too.