### PR TITLE
update urdf_config.rviz

### DIFF
--- a/sam_bot_description/rviz/urdf_config.rviz
+++ b/sam_bot_description/rviz/urdf_config.rviz
@@ -37,6 +37,23 @@ Visualization Manager:
       Show Arrows: true
       Show Axes: true
       Show Names: true
+    - Class: rviz_default_plugins/Map
+      Enabled: false
+      Name: Map
+      Topic:
+        Depth: 5
+        Durability Policy: Transient Local
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /map
+      Update Topic:
+        Depth: 5
+        Durability Policy: Transient Local
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /map_updates
+      Use Timestamp: false
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48


### PR DESCRIPTION
There are beginners who follow tutorials get confused because of two reason below.  

 - Initial Fixed Frame value of Rviz is `base_link`, not `odom` or `map`.
- Initial value of `Durability Policy` of `rviz_default_plugins` is `Volatile`, not `Transient Local`.

These can be confusing whether the `/map` topic is published or not during [this step](https://navigation.ros.org/setup_guides/sensors/setup_sensors.html#launching-slam-toolbox) 

You can see that the `map` message is visualized on the Rviz without any special action, if apply this mr. 

There is [the case](https://answers.ros.org/question/384184/ros2-foxy-slam_toolbox-doesnt-publish-map/) on ROS ANSWERS