### PR TITLE
Update display.launch.py

### DIFF
--- a/sam_bot_description/launch/display.launch.py
+++ b/sam_bot_description/launch/display.launch.py
@@ -50,7 +50,7 @@ def generate_launch_description():
                                             description='Absolute path to rviz config file'),
         launch.actions.DeclareLaunchArgument(name='use_sim_time', default_value='True',
                                             description='Flag to enable use_sim_time'),
-        launch.actions.ExecuteProcess(cmd=['gazebo', '--verbose', '-s', 'libgazebo_ros_factory.so', world_path], output='screen'),
+        launch.actions.ExecuteProcess(cmd=['gazebo', '--verbose', '-s', 'libgazebo_ros_init.so', '-s', 'libgazebo_ros_factory.so', world_path], output='screen'),
 
         joint_state_publisher_node,
         robot_state_publisher_node,


### PR DESCRIPTION
Launch `gazebo_ros_init` in `display.launch.py` to publish Gazebo simulation time to `/clock`

Fixes ros-planning#30