### PR TITLE
Update sam_bot_description.urdf

### DIFF
--- a/sam_bot_description/launch/display.launch.py
+++ b/sam_bot_description/launch/display.launch.py
@@ -50,8 +50,8 @@ def generate_launch_description():
                                             description='Absolute path to rviz config file'),
         launch.actions.DeclareLaunchArgument(name='use_sim_time', default_value='True',
                                             description='Flag to enable use_sim_time'),
-        launch.actions.ExecuteProcess(cmd=['gazebo', '--verbose', '-s', 'libgazebo_ros_factory.so', world_path], output='screen'),
-
+        launch.actions.ExecuteProcess(cmd=['gazebo', '--verbose', '-s', 'libgazebo_ros_init.so', '-s', 'libgazebo_ros_factory.so', world_path], output='screen'),
+        
         joint_state_publisher_node,
         robot_state_publisher_node,
         spawn_entity,

--- a/sam_bot_description/launch/display.launch.py
+++ b/sam_bot_description/launch/display.launch.py
@@ -50,7 +50,7 @@ def generate_launch_description():
                                             description='Absolute path to rviz config file'),
         launch.actions.DeclareLaunchArgument(name='use_sim_time', default_value='True',
                                             description='Flag to enable use_sim_time'),
-        launch.actions.ExecuteProcess(cmd=['gazebo', '--verbose', '-s', 'libgazebo_ros_init.so', '-s', 'libgazebo_ros_factory.so', world_path], output='screen'),
+        launch.actions.ExecuteProcess(cmd=['gazebo', '--verbose', '-s', 'libgazebo_ros_factory.so', world_path], output='screen'),
         
         joint_state_publisher_node,
         robot_state_publisher_node,

--- a/sam_bot_description/src/description/sam_bot_description.urdf
+++ b/sam_bot_description/src/description/sam_bot_description.urdf
@@ -240,7 +240,7 @@
 
       <!-- output -->
       <publish_odom>true</publish_odom>
-      <publish_odom_tf>true</publish_odom_tf>
+      <publish_odom_tf>false</publish_odom_tf>
       <publish_wheel_tf>true</publish_wheel_tf>
 
       <odometry_frame>odom</odometry_frame>


### PR DESCRIPTION
Disable `publish_odom_tf` of Gazebo diff drive plugin. The `odom`=>`base_link` transform is set to be published by `robot_localization`.