### PR TITLE
Switch to new-style static_transform_publisher arguments

### DIFF
--- a/nav2_gps_waypoint_follower_demo/launch/mapviz.launch.py
+++ b/nav2_gps_waypoint_follower_demo/launch/mapviz.launch.py
@@ -29,6 +29,15 @@ def generate_launch_description():
             package="tf2_ros",
             executable="static_transform_publisher",
             name="swri_transform",
-            arguments=["0", "0", "0", "0", "0", "0", "map", "origin"]
+            arguments=[
+                '--x', '0',
+                '--y', '0',
+                '--z', '0',
+                '--roll', '0',
+                '--pitch', '0',
+                '--yaw', '0',
+                '--frame-id', 'map',
+                '--child-frame-id', 'origin'
+            ]
         )
     ])


### PR DESCRIPTION
Without this, I am seeing errors when launching:

```
[static_transform_publisher-3] [ERROR 1769354804.674560981] []: error parsing command line arguments: Frame id must not be empty (main() at ./src/static_transform_broadcaster_program.cpp:303)
[ERROR] [static_transform_publisher-3]: process has died [pid 458226, exit code 1, cmd '/opt/ros/rolling/lib/tf2_ros/static_transform_publisher 0 0 0 0 0 0 map origin --ros-args -r __node:=swri_transform'].
```